### PR TITLE
Add support for managing attachments through S3

### DIFF
--- a/CTFd/config.py
+++ b/CTFd/config.py
@@ -128,6 +128,20 @@ class Config(object):
     if CACHE_TYPE == 'redis':
         CACHE_REDIS_URL = os.environ.get('REDIS_URL')
 
+    '''
+    Configuration for S3 for attachments
+
+    S3_ATTACHMENTS_ACCESS_KEY_ID is your AWS Access Key. If you do not provide this, it will try to use an IAM role or credentials file.
+
+    S3_ATTACHMENTS_SECRET_ACCESS_KEY is your AWS Secret Key. If you do not provide this, it will try to use an IAM role or credentials file.
+
+    S3_ATTACHMENTS_BUCKET is the name of your Amazon S3 bucket.
+
+    adapted from CTFd-S3-plugin https://github.com/CTFd/CTFd-S3-plugin
+    '''
+    S3_ATTACHMENTS_ACCESS_KEY_ID = os.environ.get('S3_ATTACHMENTS_ACCESS_KEY_ID')
+    S3_ATTACHMENTS_SECRET_ACCESS_KEY = os.environ.get('S3_ATTACHMENTS_SECRET_ACCESS_KEY')
+    S3_ATTACHMENTS_BUCKET = os.environ.get('S3_ATTACHMENTS_BUCKET')
 
 class TestingConfig(Config):
     PRESERVE_CONTEXT_ON_EXCEPTION = False

--- a/CTFd/utils.py
+++ b/CTFd/utils.py
@@ -1,3 +1,4 @@
+import boto3
 import datetime
 import email
 import functools
@@ -12,6 +13,7 @@ import shutil
 import smtplib
 import socket
 import subprocess
+import string
 import sys
 import tempfile
 import time
@@ -333,33 +335,87 @@ def get_configurable_plugins():
             if os.path.isfile(os.path.join(dir, name, 'config.html'))]
 
 
-def upload_file(file, chalid):
-    filename = secure_filename(file.filename)
+def clean_filename(c):
+    if c in string.ascii_letters + string.digits + '-' + '_' + '.':
+        return True
 
+
+def get_s3_conn(app):
+    access_key_id = get_config('S3_ATTACHMENTS_ACCESS_KEY_ID')
+    secret_access_key = get_config('S3_ATTACHMENTS_SECRET_ACCESS_KEY')
+    if access_key_id and secret_access_key:
+        client = boto3.client(
+            's3',
+            aws_access_key_id=access_key_id,
+            aws_secret_access_key=secret_access_key
+        )
+        bucket = get_config('S3_ATTACHMENTS_BUCKET')
+        return client, bucket
+    else:
+        client = boto3.client('s3')
+        bucket = get_config('S3_ATTACHMENTS_BUCKET')
+        return client, bucket
+
+# S3 upload_file/delete_file functions adapted from ctfd-s3-plugin https://github.com/CTFd/CTFd-S3-plugin
+
+def upload_file(file, chalid):
+    s3, bucket = get_s3_conn(app)
+
+    filename = filter(clean_filename, secure_filename(file.filename).replace(' ', '_'))
     if len(filename) <= 0:
         return False
 
     md5hash = hashlib.md5(os.urandom(64)).hexdigest()
 
-    upload_folder = os.path.join(os.path.normpath(app.root_path), app.config['UPLOAD_FOLDER'])
-    if not os.path.exists(os.path.join(upload_folder, md5hash)):
-        os.makedirs(os.path.join(upload_folder, md5hash))
+    key = md5hash + '/' + filename
+    s3.upload_fileobj(file, bucket, key)
 
-    file.save(os.path.join(upload_folder, md5hash, filename))
-    db_f = Files(chalid, (md5hash + '/' + filename))
+    db_f = Files(chalid, key)
     db.session.add(db_f)
     db.session.commit()
     return True
 
+# default upload function
 
-def delete_file(file_id):
-    f = Files.query.filter_by(id=file_id).first_or_404()
-    upload_folder = os.path.join(app.root_path, app.config['UPLOAD_FOLDER'])
-    if os.path.exists(os.path.join(upload_folder, f.location)): # Some kind of os.path.isfile issue on Windows...
-        os.unlink(os.path.join(upload_folder, f.location))
+# def upload_file(file, chalid):
+#     filename = secure_filename(file.filename)
+
+#     if len(filename) <= 0:
+#         return False
+
+#     md5hash = hashlib.md5(os.urandom(64)).hexdigest()
+
+#     upload_folder = os.path.join(os.path.normpath(app.root_path), app.config['UPLOAD_FOLDER'])
+#     if not os.path.exists(os.path.join(upload_folder, md5hash)):
+#         os.makedirs(os.path.join(upload_folder, md5hash))
+
+#     file.save(os.path.join(upload_folder, md5hash, filename))
+#     db_f = Files(chalid, (md5hash + '/' + filename))
+#     db.session.add(db_f)
+#     db.session.commit()
+#     return True
+
+
+
+def delete_file(filename):
+    s3, bucket = get_s3_conn(app)
+    f = Files.query.filter_by(id=filename).first_or_404()
+    key = f.location
+    s3.delete_object(Bucket=bucket, Key=key)
     db.session.delete(f)
     db.session.commit()
     return True
+
+# default delete function
+
+# def delete_file(file_id):
+#     f = Files.query.filter_by(id=file_id).first_or_404()
+#     upload_folder = os.path.join(app.root_path, app.config['UPLOAD_FOLDER'])
+#     if os.path.exists(os.path.join(upload_folder, f.location)): # Some kind of os.path.isfile issue on Windows...
+#         os.unlink(os.path.join(upload_folder, f.location))
+#     db.session.delete(f)
+#     db.session.commit()
+#     return True
 
 
 @cache.memoize()

--- a/CTFd/views.py
+++ b/CTFd/views.py
@@ -5,7 +5,7 @@ from flask import current_app as app, render_template, request, redirect, abort,
 from jinja2.exceptions import TemplateNotFound
 from passlib.hash import bcrypt_sha256
 
-from CTFd.models import db, Teams, Solves, Awards, Files, Pages
+from CTFd.models import db, Teams, Solves, Awards, Files, Pages, Challenges
 from CTFd.utils import cache
 from CTFd import utils
 
@@ -247,14 +247,47 @@ def profile():
 
 @views.route('/files', defaults={'path': ''})
 @views.route('/files/<path:path>')
+
+# S3 file_handler function adapted from ctfd-s3-plugin https://github.com/CTFd/CTFd-S3-plugin
+
 def file_handler(path):
     f = Files.query.filter_by(location=path).first_or_404()
-    if f.chal:
-        if not utils.is_admin():
-            if not utils.ctftime():
-                if utils.view_after_ctf() and utils.ctf_started():
-                    pass
-                else:
-                    abort(403)
-    upload_folder = os.path.join(app.root_path, app.config['UPLOAD_FOLDER'])
-    return send_file(os.path.join(upload_folder, f.location))
+    chal = Challenges.query.filter_by(id=f.chal).first()
+
+    s3, bucket = utils.get_s3_conn(app)
+    if utils.is_admin():
+        key = f.location
+        url = s3.generate_presigned_url('get_object', Params = {
+            'Bucket': bucket,
+            'Key': key, })
+        return redirect(url)
+
+    if utils.user_can_view_challenges():
+        if not utils.ctftime():
+            if not utils.view_after_ctf():
+                abort(403)
+
+        if chal.hidden:
+            abort(403)
+
+        key = f.location
+        url = s3.generate_presigned_url('get_object', Params = {
+            'Bucket': bucket,
+            'Key': key, })
+        return redirect(url)
+    else:
+        return redirect(url_for('auth.login'))
+
+# default file_handler function
+
+# def file_handler(path):
+#     f = Files.query.filter_by(location=path).first_or_404()
+#     if f.chal:
+#         if not utils.is_admin():
+#             if not utils.ctftime():
+#                 if utils.view_after_ctf() and utils.ctf_started():
+#                     pass
+#                 else:
+#                     abort(403)
+#     upload_folder = os.path.join(app.root_path, app.config['UPLOAD_FOLDER'])
+#     return send_file(os.path.join(upload_folder, f.location))


### PR DESCRIPTION
Adapted functions for forming S3 urls, uploading and deleting file attachments from the [CTFd-S3-plugin](https://github.com/CTFd/CTFd-S3-plugin).

#### To Test: 
1. Get creds from @danielhtrauner and set **ENV variables** for:
```
S3_ATTACHMENTS_ACCESS_KEY_ID
S3_ATTACHMENTS_SECRET_ACCESS_KEY
S3_ATTACHMENTS_BUCKET
```
2. Seed db with `python populate.py`
3. Go to `/admin/chals` click on a challenge and try to upload a file